### PR TITLE
Add jumpserver_host resource to manage Jumpserver hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your `main.tf` file to use the Jumpserver provider:
 terraform {
   required_providers {
     jumpserver = {
-      source  = "atwatanmalikm/jumpserver"
+      source  = "gustavo-bolis/jumpserver"
       version = "~> 1.0.0"
     }
   }

--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -1,0 +1,75 @@
+
+# `jumpserver_host` Resource
+
+The `jumpserver_host` resource allows you to create and manage *hosts* in Jumpserver. A host represents a specific server/endpoint that Jumpserver will manage. This resource also supports creating SSH accounts (or other protocols) on the host.
+
+## Example Usage
+
+```hcl
+resource "jumpserver_host" "example_host" {
+  # Basic host info
+  name      = "server-lxc1"
+  address   = "10.10.10.50"
+  platform  = 32
+
+  # Domain and Node by name
+  domain_name = "Production"
+  node_name   = "Linux Servers"
+
+  # Define SSH accounts
+  accounts {
+    on_invalid   = "error"
+    is_active    = true
+    name         = "root"
+    username     = "root"
+    secret_type  = "ssh_key"
+    secret       = file("${path.module}/ssh_key/id_ed25519")
+  }
+
+  # Define protocols
+  protocols {
+    name = "ssh"
+    port = 22
+  }
+  protocols {
+    name = "sftp"
+    port = 22
+  }
+}
+```
+
+## Argument Reference
+
+- **`name`** - (Required) The name of the host in Jumpserver.
+- **`address`** - (Required) The IP address (or hostname) of the host.
+- **`platform`** - (Required) The platform code for this host (e.g., `32` for Linux).
+
+- **`domain_name`** - (Required) The **name** of the Domain (Zone) in Jumpserver that this host should belong to. The provider will look up the Domain by its `name` and retrieve its ID to associate the host.
+- **`node_name`** - (Required) The **name** of the Node in Jumpserver that this host should belong to. The provider will look up the Node by its `name` and retrieve its ID to associate the host.
+
+- **`accounts`** - (Optional) A list of account definitions for this host.
+    - **`on_invalid`** - (Optional) Action if the credential becomes invalid. Defaults to `"error"`.
+    - **`is_active`** - (Optional) Whether the account is active. Defaults to `true`.
+    - **`name`** - (Required) An identifier for the account (e.g., `"root"`).
+    - **`username`** - (Required) The actual username on the host.
+    - **`secret_type`** - (Required) The type of secret (e.g., `"ssh_key"` or `"password"`).
+    - **`secret`** - (Required, Sensitive) The key or password used for authentication.
+
+- **`protocols`** - (Optional) A list of protocols the host can be accessed by.
+    - **`name`** - (Required) The name of the protocol (e.g., `"ssh"`, `"sftp"`).
+    - **`port`** - (Required) The port number for that protocol.
+
+## Attribute Reference
+
+In addition to the arguments above, the following attributes are exported:
+
+- **`id`** - The ID of the host in Jumpserver.
+- **`domain_id`** - The actual domain (zone) ID used in Jumpserver. (Computed at create-time if you supply `domain_name`.)
+- **`node_ids`** - A list of node IDs (in Jumpserver) this host is attached to. (Computed at create-time if you supply `node_name`.)
+
+## Notes
+
+- If the specified `domain_name` or `node_name` do not exist in Jumpserver, creation of the host fails. This resource does **not** create or delete domains/nodes.
+- During updates:
+    - If you change `domain_name` or `node_name`, the provider will look up new IDs and update the host accordingly.
+- During `destroy`, only the host is deleted. Domains and nodes remain intact.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atwatanmalikm/terraform-provider-jumpserver
+module github.com/gustavo-bolis/terraform-provider-jumpserver
 
 go 1.22.5
 

--- a/jumpserver/provider.go
+++ b/jumpserver/provider.go
@@ -3,18 +3,21 @@ package jumpserver
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"net/http"
 )
 
 type Config struct {
-	Token    string
-	BaseURL  string
-	Username string
-	Password string
+	Token         string
+	BaseURL       string
+	Username      string
+	Password      string
+	SkipTLSVerify bool
 }
 
 func Provider() *schema.Provider {
@@ -32,6 +35,12 @@ func Provider() *schema.Provider {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+			},
+			"skip_tls_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, skip SSL certificate validation (insecure).",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -51,39 +60,52 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	baseURL := d.Get("base_url").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
+	skipTLS := d.Get("skip_tls_verify").(bool)
 
-	// Get Token
-	token, err := getToken(baseURL, username, password)
+	token, err := getToken(baseURL, username, password, skipTLS)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
 
 	return &Config{
-		Token:    token,
-		BaseURL:  baseURL,
-		Username: username,
-		Password: password,
+		Token:         token,
+		BaseURL:       baseURL,
+		Username:      username,
+		Password:      password,
+		SkipTLSVerify: skipTLS,
 	}, diags
 }
 
-func getToken(baseURL, username, password string) (string, error) {
+func getToken(baseURL, username, password string, skipTLS bool) (string, error) {
+	// Monta um *http.Client* que pula a validação de TLS quando skipTLS == true.
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: skipTLS,
+		},
+	}
+	client := &http.Client{Transport: transport}
+
 	url := baseURL + "/api/v1/authentication/auth/"
 	credentials := map[string]string{
 		"username": username,
 		"password": password,
 	}
+
 	jsonValue, _ := json.Marshal(credentials)
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonValue))
+
+	resp, err := client.Post(url, "application/json", bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
 	var result map[string]interface{}
-	json.NewDecoder(resp.Body).Decode(&result)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
 
 	if token, ok := result["token"].(string); ok {
 		return token, nil
 	}
-	return "", fmt.Errorf("unable to fetch token")
+	return "", fmt.Errorf("unable to fetch token from %s", url)
 }

--- a/jumpserver/provider.go
+++ b/jumpserver/provider.go
@@ -35,6 +35,7 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"jumpserver_host":             resourceHost(),
 			"jumpserver_user":             resourceUser(),
 			"jumpserver_asset":            resourceAsset(),
 			"jumpserver_system_user":      resourceSystemUser(),

--- a/jumpserver/resource_host.go
+++ b/jumpserver/resource_host.go
@@ -28,6 +28,10 @@ func resourceHost() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"platform": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -135,6 +139,10 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface
 		"nodes":    []string{nodeID},
 	}
 
+	if v, ok := d.GetOk("comment"); ok {
+		hostData["comment"] = v.(string)
+	}
+
 	if v, ok := d.GetOk("accounts"); ok {
 		hostData["accounts"] = expandAccounts(v.([]interface{}))
 	}
@@ -223,6 +231,9 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	if address, ok := result["address"].(string); ok {
 		d.Set("address", address)
 	}
+	if comment, ok := result["comment"].(string); ok {
+		d.Set("comment", comment)
+	}
 	if platform, ok := result["platform"].(float64); ok {
 		d.Set("platform", int(platform))
 	}
@@ -282,6 +293,10 @@ func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		"platform": d.Get("platform").(int),
 		"domain":   domainID,
 		"nodes":    []string{nodeID},
+	}
+
+	if v, ok := d.GetOk("comment"); ok {
+		hostData["comment"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("accounts"); ok {

--- a/jumpserver/resource_host.go
+++ b/jumpserver/resource_host.go
@@ -156,7 +156,7 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return diag.FromErr(err)
@@ -198,7 +198,7 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return diag.FromErr(err)
@@ -304,7 +304,7 @@ func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return diag.FromErr(err)
@@ -332,7 +332,7 @@ func resourceHostDelete(ctx context.Context, d *schema.ResourceData, m interface
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return diag.FromErr(err)
@@ -358,7 +358,7 @@ func findDomainIDByName(c *Config, domainName string) (string, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -395,7 +395,7 @@ func findNodeIDByName(c *Config, nodeName string) (string, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
 
-	client := &http.Client{}
+	client := c.NewHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/jumpserver/resource_host.go
+++ b/jumpserver/resource_host.go
@@ -1,0 +1,484 @@
+package jumpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceHost() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostCreate,
+		ReadContext:   resourceHostRead,
+		UpdateContext: resourceHostUpdate,
+		DeleteContext: resourceHostDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"platform": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"accounts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"on_invalid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "error",
+						},
+						"is_active": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"secret_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"secret": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+
+			"protocols": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// -------------------------------------------------------------------
+// Create
+// -------------------------------------------------------------------
+func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*Config)
+	var diags diag.Diagnostics
+
+	domainName := d.Get("domain_name").(string)
+	domainID, err := findDomainIDByName(c, domainName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nodeName := d.Get("node_name").(string)
+	nodeID, err := findNodeIDByName(c, nodeName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	hostData := map[string]interface{}{
+		"name":     d.Get("name").(string),
+		"address":  d.Get("address").(string),
+		"platform": d.Get("platform").(int),
+		"domain":   domainID,
+		"nodes":    []string{nodeID},
+	}
+
+	if v, ok := d.GetOk("accounts"); ok {
+		hostData["accounts"] = expandAccounts(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("protocols"); ok {
+		hostData["protocols"] = expandProtocols(v.([]interface{}))
+	}
+
+	jsonValue, err := json.Marshal(hostData)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/assets/hosts/", c.BaseURL)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return diag.Errorf("Failed to create host in JumpServer. HTTP status: %d", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return diag.FromErr(err)
+	}
+
+	hostID, ok := result["id"].(string)
+	if !ok {
+		return diag.Errorf("No 'id' field found in host creation response")
+	}
+	d.SetId(hostID)
+
+	d.Set("domain_id", domainID)
+	d.Set("node_ids", []string{nodeID})
+
+	return diags
+}
+
+// -------------------------------------------------------------------
+// Read
+// -------------------------------------------------------------------
+func resourceHostRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*Config)
+	var diags diag.Diagnostics
+
+	url := fmt.Sprintf("%s/api/v1/assets/hosts/%s/", c.BaseURL, d.Id())
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return diags
+	} else if resp.StatusCode != http.StatusOK {
+		return diag.Errorf("Failed to read host. HTTP status: %d", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if name, ok := result["name"].(string); ok {
+		d.Set("name", name)
+	}
+	if address, ok := result["address"].(string); ok {
+		d.Set("address", address)
+	}
+	if platform, ok := result["platform"].(float64); ok {
+		d.Set("platform", int(platform))
+	}
+	if domain, ok := result["domain"].(string); ok {
+		d.Set("domain_id", domain)
+	}
+	if nodes, ok := result["nodes"].([]interface{}); ok {
+		d.Set("node_ids", nodes)
+	}
+
+	if accounts, ok := result["accounts"].([]interface{}); ok {
+		d.Set("accounts", flattenAccounts(accounts))
+	}
+	if protocols, ok := result["protocols"].([]interface{}); ok {
+		d.Set("protocols", flattenProtocols(protocols))
+	}
+
+	return diags
+}
+
+// -------------------------------------------------------------------
+// Update
+// -------------------------------------------------------------------
+func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*Config)
+
+	domainID := d.Get("domain_id").(string)
+	nodeIDsRaw := d.Get("node_ids").([]interface{})
+	var nodeID string
+	if len(nodeIDsRaw) > 0 {
+		nodeID = nodeIDsRaw[0].(string)
+	}
+
+	if d.HasChange("domain_name") {
+		newDomainName := d.Get("domain_name").(string)
+		foundID, err := findDomainIDByName(c, newDomainName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		domainID = foundID
+		d.Set("domain_id", foundID)
+	}
+
+	if d.HasChange("node_name") {
+		newNodeName := d.Get("node_name").(string)
+		foundID, err := findNodeIDByName(c, newNodeName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		nodeID = foundID
+		d.Set("node_ids", []string{foundID})
+	}
+
+	hostData := map[string]interface{}{
+		"name":     d.Get("name").(string),
+		"address":  d.Get("address").(string),
+		"platform": d.Get("platform").(int),
+		"domain":   domainID,
+		"nodes":    []string{nodeID},
+	}
+
+	if v, ok := d.GetOk("accounts"); ok {
+		hostData["accounts"] = expandAccounts(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("protocols"); ok {
+		hostData["protocols"] = expandProtocols(v.([]interface{}))
+	}
+
+	jsonValue, err := json.Marshal(hostData)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/assets/hosts/%s/", c.BaseURL, d.Id())
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return diag.Errorf("Failed to update host. HTTP status: %d", resp.StatusCode)
+	}
+
+	return resourceHostRead(ctx, d, m)
+}
+
+// -------------------------------------------------------------------
+// Delete
+// -------------------------------------------------------------------
+func resourceHostDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*Config)
+	var diags diag.Diagnostics
+
+	url := fmt.Sprintf("%s/api/v1/assets/hosts/%s/", c.BaseURL, d.Id())
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return diag.Errorf("Failed to delete host. HTTP status: %d", resp.StatusCode)
+	}
+
+	d.SetId("")
+	return diags
+}
+
+// -------------------------------------------------------------------
+// Get domain_id / node_id from domain_name / node_name
+// -------------------------------------------------------------------
+func findDomainIDByName(c *Config, domainName string) (string, error) {
+	url := fmt.Sprintf("%s/api/v1/assets/domains/", c.BaseURL)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to list domains, status=%d", resp.StatusCode)
+	}
+
+	var domains []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&domains); err != nil {
+		return "", err
+	}
+
+	for _, dom := range domains {
+		if domName, ok := dom["name"].(string); ok {
+			if strings.EqualFold(domName, domainName) {
+				if id, idOk := dom["id"].(string); idOk {
+					return id, nil
+				}
+				return "", fmt.Errorf("domain '%s' found but has no 'id'", domainName)
+			}
+		}
+	}
+	return "", fmt.Errorf("domain '%s' not found in JumpServer", domainName)
+}
+
+func findNodeIDByName(c *Config, nodeName string) (string, error) {
+	url := fmt.Sprintf("%s/api/v1/assets/nodes/", c.BaseURL)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to list nodes, status=%d", resp.StatusCode)
+	}
+
+	var nodes []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+		return "", err
+	}
+
+	for _, node := range nodes {
+		if nodeNameAPI, ok := node["name"].(string); ok {
+			if strings.EqualFold(nodeNameAPI, nodeName) {
+				if id, idOk := node["id"].(string); idOk {
+					return id, nil
+				}
+				return "", fmt.Errorf("node '%s' found but has no 'id'", nodeName)
+			}
+		}
+	}
+	return "", fmt.Errorf("node '%s' not found in JumpServer", nodeName)
+}
+
+func expandAccounts(list []interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	for _, item := range list {
+		m := item.(map[string]interface{})
+		acc := map[string]interface{}{
+			"on_invalid":  m["on_invalid"].(string),
+			"is_active":   m["is_active"].(bool),
+			"name":        m["name"].(string),
+			"username":    m["username"].(string),
+			"secret_type": m["secret_type"].(string),
+			"secret":      m["secret"].(string),
+		}
+		result = append(result, acc)
+	}
+	return result
+}
+
+func expandProtocols(list []interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	for _, item := range list {
+		m := item.(map[string]interface{})
+		proto := map[string]interface{}{
+			"name": m["name"].(string),
+			"port": m["port"].(int),
+		}
+		result = append(result, proto)
+	}
+	return result
+}
+
+func flattenAccounts(accounts []interface{}) []interface{} {
+	var result []interface{}
+	for _, a := range accounts {
+		m := a.(map[string]interface{})
+		acc := map[string]interface{}{
+			"on_invalid":  m["on_invalid"],
+			"is_active":   m["is_active"],
+			"name":        m["name"],
+			"username":    m["username"],
+			"secret_type": m["secret_type"],
+		}
+		result = append(result, acc)
+	}
+	return result
+}
+
+func flattenProtocols(protocols []interface{}) []interface{} {
+	var result []interface{}
+	for _, p := range protocols {
+		m := p.(map[string]interface{})
+		proto := map[string]interface{}{
+			"name": m["name"],
+			"port": m["port"],
+		}
+		result = append(result, proto)
+	}
+	return result
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/atwatanmalikm/terraform-provider-jumpserver/jumpserver"
+	"github.com/gustavo-bolis/terraform-provider-jumpserver/jumpserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 


### PR DESCRIPTION
This pull request introduces a new jumpserver_host resource to the provider, enabling Terraform to create, update, and remove hosts directly in Jumpserver. The implementation focuses on associating hosts with existing domains and nodes without altering or deleting those external resources. This provides a straightforward way for users to manage hosts from Terraform while ensuring domain and node objects remain intact.